### PR TITLE
added check if .iota-is.json exists before deleting

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,10 @@ export const configure = async (options: {
         checkConfig(isGatewayUrl, ssiBridgeUrl, auditTrailUrl);
 
         // Delete the old config when a new one is created
-        fs.unlinkSync(path.join(os.homedir(), '.iota-is.json'));
+        if (fs.existsSync(path.join(os.homedir(), '.iota-is.json'))) {
+            fs.unlinkSync(path.join(os.homedir(), '.iota-is.json'));
+        }
+
         nconf
             .argv()
             .env()


### PR DESCRIPTION
# Description of change

Added check for existing of .iota-is.json before deleting it when trying to run the config command.


## Type of change

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

Manually by running the config command when the file doesn't exist and if the file exist.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code